### PR TITLE
Install systemd inside Docker containers for Beaker tests

### DIFF
--- a/spec/acceptance/nodesets/debian9.yml
+++ b/spec/acceptance/nodesets/debian9.yml
@@ -5,7 +5,7 @@ HOSTS:
     image: debian:9
     docker_preserve_image: true
     docker_image_commands:
-      - 'apt-get update && apt-get install -y cron locales-all net-tools wget git vim apt-transport-https'
+      - 'apt-get update && apt-get install -y cron locales-all net-tools wget git vim apt-transport-https systemd'
       - 'rm -f /usr/sbin/policy-rc.d'
 CONFIG:
   trace_limit: 200


### PR DESCRIPTION
For running certain tests (see https://github.com/vision-it/vision-docker/issues/3#issuecomment-347268086), Beaker requires systemd inside the Docker container.
Since systemd is no longer part of the base debian stretch (9) image, we need to install it manually (via debian9.yaml)